### PR TITLE
fix: explicitly indicate parser: none

### DIFF
--- a/src/sentences-per-line.ts
+++ b/src/sentences-per-line.ts
@@ -125,5 +125,6 @@ export const sentencesPerLine = {
 		}
 	},
 	names: ["sentences-per-line"],
+	parser: "none",
 	tags: ["sentences"],
-};
+} satisfies markdownlint.Rule;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #635
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the property and uses a `satisfies` to ensure the `sentencesPerLine` export is tyed per `markdownlint.Rule`.

💖 