### PR TITLE
fix: remove test files from build output

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,8 @@
 	"ignoreExportsUsedInFile": { "interface": true, "type": true },
 	"workspaces": {
 		"packages/eslint-plugin-sentences-per-line": {
-			"entry": [".eslint-doc-generatorrc.js"]
+			"entry": ["src/index.ts"],
+			"ignoreFiles": [".eslint-doc-generatorrc.js"]
 		},
 		"packages/markdownlint-sentences-per-line": {
 			"project": ["src/**/*.ts!"]

--- a/packages/eslint-plugin-sentences-per-line/package.json
+++ b/packages/eslint-plugin-sentences-per-line/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"main": "./lib/index.js",
 	"files": [
-		"lib/"
+		"lib/",
+		"!lib/tsconfig.build.tsbuildinfo"
 	],
 	"scripts": {
 		"build:docs": "eslint-doc-generator",

--- a/packages/eslint-plugin-sentences-per-line/tsconfig.build.json
+++ b/packages/eslint-plugin-sentences-per-line/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../tsconfig.base.build.json",
+	"include": ["src"],
+	"exclude": ["**/*.test.ts", "**/ruleTester.ts"]
+}

--- a/packages/eslint-plugin-sentences-per-line/tsconfig.json
+++ b/packages/eslint-plugin-sentences-per-line/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"compilerOptions": {
-		"outDir": "lib",
 		"rootDir": "src"
 	},
 	"extends": "../../tsconfig.base.json",
-	"include": ["src"],
-	"references": [{ "path": "../sentences-per-line" }]
+	"include": ["src"]
 }

--- a/packages/markdownlint-sentences-per-line/package.json
+++ b/packages/markdownlint-sentences-per-line/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"main": "lib/index.js",
 	"files": [
-		"lib/"
+		"lib/",
+		"!lib/tsconfig.build.tsbuildinfo"
 	],
 	"dependencies": {
 		"markdownlint-rule-helpers": "^0.30.0",

--- a/packages/markdownlint-sentences-per-line/tsconfig.build.json
+++ b/packages/markdownlint-sentences-per-line/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../tsconfig.base.build.json",
+	"include": ["src"],
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/markdownlint-sentences-per-line/tsconfig.json
+++ b/packages/markdownlint-sentences-per-line/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"compilerOptions": {
-		"outDir": "lib",
 		"rootDir": "src"
 	},
 	"extends": "../../tsconfig.base.json",
-	"include": ["src"],
-	"references": [{ "path": "../sentences-per-line" }]
+	"include": ["src"]
 }

--- a/packages/prettier-plugin-sentences-per-line/package.json
+++ b/packages/prettier-plugin-sentences-per-line/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"main": "lib/index.js",
 	"files": [
-		"lib/"
+		"lib/",
+		"!lib/tsconfig.build.tsbuildinfo"
 	],
 	"dependencies": {
 		"sentences-per-line": "workspace:~"

--- a/packages/prettier-plugin-sentences-per-line/tsconfig.build.json
+++ b/packages/prettier-plugin-sentences-per-line/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../tsconfig.base.build.json",
+	"include": ["src"],
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/prettier-plugin-sentences-per-line/tsconfig.json
+++ b/packages/prettier-plugin-sentences-per-line/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"outDir": "lib",
 		"rootDir": "src",
 		"types": ["node", "mdast"]
 	},

--- a/packages/sentences-per-line/package.json
+++ b/packages/sentences-per-line/package.json
@@ -19,7 +19,8 @@
 	},
 	"main": "./src/index.ts",
 	"files": [
-		"lib/"
+		"lib/",
+		"!lib/tsconfig.build.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=22.14.0"

--- a/packages/sentences-per-line/tsconfig.build.json
+++ b/packages/sentences-per-line/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../tsconfig.base.build.json",
+	"include": ["src"],
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/sentences-per-line/tsconfig.json
+++ b/packages/sentences-per-line/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"outDir": "lib",
 		"rootDir": "src"
 	},
 	"extends": "../../tsconfig.base.json",

--- a/tsconfig.base.build.json
+++ b/tsconfig.base.build.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"allowJs": false,
+		"composite": false,
+		"declaration": true,
+		"declarationMap": true,
+		"noEmit": false,
+		"outDir": "${configDir}/lib"
+	}
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,13 +1,15 @@
 {
-	"compilerOptions": {
-		"noEmit": false
-	},
-	"extends": "./tsconfig.base.json",
 	"files": [],
 	"references": [
-		{ "path": "./packages/eslint-plugin-sentences-per-line" },
-		{ "path": "./packages/markdownlint-sentences-per-line" },
-		{ "path": "./packages/prettier-plugin-sentences-per-line" },
-		{ "path": "./packages/sentences-per-line" }
+		{
+			"path": "./packages/eslint-plugin-sentences-per-line/tsconfig.build.json"
+		},
+		{
+			"path": "./packages/markdownlint-sentences-per-line/tsconfig.build.json"
+		},
+		{
+			"path": "./packages/prettier-plugin-sentences-per-line/tsconfig.build.json"
+		},
+		{ "path": "./packages/sentences-per-line/tsconfig.build.json" }
 	]
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to sentences-per-line! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Currently test files are included in the published package:

https://www.npmjs.com/package/prettier-plugin-sentences-per-line?activeTab=code

<img width="812" height="812" alt="test files in build output on npm" src="https://github.com/user-attachments/assets/14291b75-ff14-46b2-96e1-22efabdc4590" />

To avoid their inclusion in the published package I created a `tsconfig.build.json` for each package and referenced it from the root `tsconfig.build.json`
