### PR TITLE
fix(sentences-per-line): handle backslash with backtick

### DIFF
--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
@@ -15,6 +15,7 @@ describe(getIndexBeforeSecondSentence, () => {
 		["``Abc.`` Def.", undefined],
 		["`Abc.` Def. Ghi", 11],
 		["```js```.", undefined],
+		["`C:\\`", undefined],
 		[
 			`
 \`\`\`plaintext

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
@@ -61,6 +61,9 @@ function getNextIndexNotInCode(line: string, i: number) {
 		if (line[i - 1] !== "\\") {
 			break;
 		}
+		else {
+			i += 1;
+		}
 	}
 
 	while (line[i] === "`") {

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
@@ -60,8 +60,7 @@ function getNextIndexNotInCode(line: string, i: number) {
 
 		if (line[i - 1] !== "\\") {
 			break;
-		}
-		else {
+		} else {
 			i += 1;
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #888 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Added test for case with "\`" in line.
- Fixed endless loop when line contains "\`"
