### PR TITLE
feat: add options for additional abbreviations

### DIFF
--- a/packages/eslint-plugin-sentences-per-line/README.md
+++ b/packages/eslint-plugin-sentences-per-line/README.md
@@ -50,6 +50,29 @@ export default [
 ];
 ```
 
+### Options
+
+#### `additionalAbbreviations`
+
+An array of custom abbreviations to ignore when determining sentence boundaries.
+
+These will be added to the standard list of abbreviations below.
+
+`["eg.", "e.g.", "etc.", "ex.", "ie.", "i.e.", "vs."]`
+
+```ts
+export default [
+	{
+		rules: {
+			"sentences-per-line/one": [
+				"error",
+				{ additionalAbbreviations: ["Mme."] },
+			],
+		},
+	},
+];
+```
+
 ## Rules
 
 <!-- prettier-ignore-start -->

--- a/packages/eslint-plugin-sentences-per-line/docs/rules/one.md
+++ b/packages/eslint-plugin-sentences-per-line/docs/rules/one.md
@@ -27,3 +27,26 @@ Example of **correct** code for this rule:
 First sentence.
 Second sentence
 ```
+
+## Options
+
+### `additionalAbbreviations`
+
+An array of custom abbreviations to ignore when determining sentence boundaries.
+
+These will be added to the standard list of abbreviations below.
+
+`["eg.", "e.g.", "etc.", "ex.", "ie.", "i.e.", "vs."]`
+
+```js
+export default [
+	{
+		rules: {
+			"sentences-per-line/one": [
+				"error",
+				{ additionalAbbreviations: ["Mme."] },
+			],
+		},
+	},
+];
+```

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
@@ -107,6 +107,33 @@ Def.
 			],
 			output: "1. Hello! \nWorld.",
 		},
+		{
+			code: "Bonjour Mme. Dupont.",
+			errors: [
+				{
+					column: 13,
+					endColumn: 14,
+					endLine: 1,
+					line: 1,
+					messageId: "multiple",
+				},
+			],
+			output: "Bonjour Mme. \nDupont.",
+		},
+		{
+			code: "Bonjour Mme. Dupont.",
+			errors: [
+				{
+					column: 13,
+					endColumn: 14,
+					endLine: 1,
+					line: 1,
+					messageId: "multiple",
+				},
+			],
+			options: [{ additionalAbbreviations: ["Mlle."] }],
+			output: "Bonjour Mme. \nDupont.",
+		},
 	],
 	valid: [
 		"",
@@ -136,5 +163,9 @@ Def.
 		"`Hello?` World.",
 		"Hello!",
 		"Hello?",
+		{
+			code: "Bonjour Mme. Dupont.",
+			options: [{ additionalAbbreviations: ["Mme."] }],
+		},
 	],
 });

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
@@ -57,7 +57,6 @@ export const one: MarkdownRuleDefinition<{
 		};
 	},
 	meta: {
-		defaultOptions: [{ additionalAbbreviations: [] }],
 		docs: {
 			description: "Limits Markdown sentences to one per line.",
 		},

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
@@ -2,10 +2,23 @@ import { MarkdownRuleDefinition } from "@eslint/markdown";
 import { Paragraph, Text } from "mdast";
 import { getIndexBeforeSecondSentence } from "sentences-per-line";
 
-export const one: MarkdownRuleDefinition = {
+export interface OneOptions {
+	additionalAbbreviations?: string[];
+}
+
+export const one: MarkdownRuleDefinition<{
+	MessageIds: "multiple";
+	RuleOptions: [OneOptions?];
+}> = {
 	create(context) {
+		const additionalAbbreviations =
+			context.options[0]?.additionalAbbreviations ?? [];
+
 		function checkTextNode(node: Text) {
-			const index = getIndexBeforeSecondSentence(node.value);
+			const index = getIndexBeforeSecondSentence(
+				node.value,
+				additionalAbbreviations,
+			);
 			if (!index) {
 				return;
 			}
@@ -44,6 +57,7 @@ export const one: MarkdownRuleDefinition = {
 		};
 	},
 	meta: {
+		defaultOptions: [{ additionalAbbreviations: [] }],
 		docs: {
 			description: "Limits Markdown sentences to one per line.",
 		},
@@ -51,7 +65,20 @@ export const one: MarkdownRuleDefinition = {
 		messages: {
 			multiple: "Each sentence should be on its own line.",
 		},
-		schema: [],
+		schema: [
+			{
+				additionalProperties: false,
+				properties: {
+					additionalAbbreviations: {
+						description:
+							"Additional abbreviations to ignore when determining sentence boundaries.",
+						items: { type: "string" },
+						type: "array",
+					},
+				},
+				type: "object",
+			},
+		],
 		type: "problem",
 	},
 };

--- a/packages/markdownlint-sentences-per-line/README.md
+++ b/packages/markdownlint-sentences-per-line/README.md
@@ -43,7 +43,7 @@ markdownlint --rules markdownlint-sentences-per-line
 
 ### Options
 
-#### `additionalAbbreviations`
+#### `additional_abbreviations`
 
 An array of custom abbreviations to ignore when determining sentence boundaries.
 
@@ -56,7 +56,7 @@ Provide them under the rule's name in your [markdownlint configuration](https://
 ```json
 {
 	"markdownlint-sentences-per-line": {
-		"additionalAbbreviations": ["Mme."]
+		"additional_abbreviations": ["Mme."]
 	}
 }
 ```

--- a/packages/markdownlint-sentences-per-line/README.md
+++ b/packages/markdownlint-sentences-per-line/README.md
@@ -41,6 +41,26 @@ Then provide it to [markdownlint-cli's `--rules`](https://github.com/igorshubovy
 markdownlint --rules markdownlint-sentences-per-line
 ```
 
+### Options
+
+#### `additionalAbbreviations`
+
+An array of custom abbreviations to ignore when determining sentence boundaries.
+
+These will be added to the standard list of abbreviations below.
+
+`["eg.", "e.g.", "etc.", "ex.", "ie.", "i.e.", "vs."]`
+
+Provide them under the rule's name in your [markdownlint configuration](https://github.com/DavidAnson/markdownlint/blob/main/README.md#optionsconfig):
+
+```json
+{
+	"markdownlint-sentences-per-line": {
+		"additionalAbbreviations": ["Mme."]
+	}
+}
+```
+
 ## Alternatives
 
 This package is part of the [sentences-per-line](https://github.com/JoshuaKGoldberg/sentences-per-line) family of packages.

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
@@ -179,12 +179,12 @@ Abc. Def.
 		});
 	});
 
-	test("reports no errors when given a French abbreviation in additionalAbbreviations", () => {
+	test("reports no errors when given a French abbreviation in additional_abbreviations", () => {
 		const actual = markdownlint.lint({
 			config: {
 				default: false,
 				"markdownlint-sentences-per-line": {
-					additionalAbbreviations: ["Mme."],
+					additional_abbreviations: ["Mme."],
 				},
 			},
 			customRules: [markdownlintSentencesPerLine],

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
@@ -146,4 +146,51 @@ Abc. Def.
 				: [],
 		});
 	});
+
+	test("reports an error when given a French abbreviation that is not configured", () => {
+		const actual = markdownlint.lint({
+			config: {
+				default: false,
+				"markdownlint-sentences-per-line": true,
+			},
+			customRules: [markdownlintSentencesPerLine],
+			strings: { input: "Bonjour Mme. Dupont." },
+		});
+
+		expect(actual).toEqual({
+			input: [
+				{
+					errorContext: "our Mme. D",
+					errorDetail: null,
+					errorRange: null,
+					fixInfo: {
+						deleteCount: 1,
+						editColumn: 13,
+						insertText: "\n",
+						lineNumber: 1,
+					},
+					lineNumber: 1,
+					ruleDescription: "Each sentence should be on its own line",
+					ruleInformation: null,
+					ruleNames: ["markdownlint-sentences-per-line"],
+					severity: "error",
+				},
+			],
+		});
+	});
+
+	test("reports no errors when given a French abbreviation in additionalAbbreviations", () => {
+		const actual = markdownlint.lint({
+			config: {
+				default: false,
+				"markdownlint-sentences-per-line": {
+					additionalAbbreviations: ["Mme."],
+				},
+			},
+			customRules: [markdownlintSentencesPerLine],
+			strings: { input: "Bonjour Mme. Dupont." },
+		});
+
+		expect(actual).toEqual({ input: [] });
+	});
 });

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
@@ -193,4 +193,53 @@ Abc. Def.
 
 		expect(actual).toEqual({ input: [] });
 	});
+
+	test("reports an error when additional_abbreviations is not an array", () => {
+		const actual = markdownlint.lint({
+			config: {
+				default: false,
+				"markdownlint-sentences-per-line": {
+					additional_abbreviations: "Mme.",
+				},
+			},
+			customRules: [markdownlintSentencesPerLine],
+			strings: { input: "Bonjour Mme. Dupont." },
+		});
+
+		expect(actual).toEqual({
+			input: [
+				{
+					errorContext: "our Mme. D",
+					errorDetail: null,
+					errorRange: null,
+					fixInfo: {
+						deleteCount: 1,
+						editColumn: 13,
+						insertText: "\n",
+						lineNumber: 1,
+					},
+					lineNumber: 1,
+					ruleDescription: "Each sentence should be on its own line",
+					ruleInformation: null,
+					ruleNames: ["markdownlint-sentences-per-line"],
+					severity: "error",
+				},
+			],
+		});
+	});
+
+	test("reports no errors when additional_abbreviations also contains a non-string entry", () => {
+		const actual = markdownlint.lint({
+			config: {
+				default: false,
+				"markdownlint-sentences-per-line": {
+					additional_abbreviations: [123, "Mme."],
+				},
+			},
+			customRules: [markdownlintSentencesPerLine],
+			strings: { input: "Bonjour Mme. Dupont." },
+		});
+
+		expect(actual).toEqual({ input: [] });
+	});
 });

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.ts
@@ -7,12 +7,12 @@ const getAdditionalAbbreviations = (config: unknown): string[] => {
 	if (
 		typeof config !== "object" ||
 		config === null ||
-		!("additionalAbbreviations" in config)
+		!("additional_abbreviations" in config)
 	) {
 		return [];
 	}
 
-	const { additionalAbbreviations } = config;
+	const { additional_abbreviations: additionalAbbreviations } = config;
 
 	return Array.isArray(additionalAbbreviations)
 		? additionalAbbreviations.filter(

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.ts
@@ -3,12 +3,32 @@ import type * as markdownlint from "markdownlint";
 import helpers from "markdownlint-rule-helpers";
 import { getIndexBeforeSecondSentence } from "sentences-per-line";
 
+const getAdditionalAbbreviations = (config: unknown): string[] => {
+	if (
+		typeof config !== "object" ||
+		config === null ||
+		!("additionalAbbreviations" in config)
+	) {
+		return [];
+	}
+
+	const { additionalAbbreviations } = config;
+
+	return Array.isArray(additionalAbbreviations)
+		? additionalAbbreviations.filter(
+				(abbreviation): abbreviation is string =>
+					typeof abbreviation === "string",
+			)
+		: [];
+};
+
 const visitLine = (
 	line: string,
 	lineNumber: number,
 	onError: markdownlint.RuleOnError,
+	additionalAbbreviations: string[],
 ) => {
-	const start = getIndexBeforeSecondSentence(line);
+	const start = getIndexBeforeSecondSentence(line, additionalAbbreviations);
 	if (start) {
 		helpers.addError(
 			onError,
@@ -32,6 +52,7 @@ export const markdownlintSentencesPerLine = {
 		params: markdownlint.RuleParams,
 		onError: markdownlint.RuleOnError,
 	) => {
+		const additionalAbbreviations = getAdditionalAbbreviations(params.config);
 		let inFenceLine = false;
 
 		for (let i = 0; i < params.lines.length; i += 1) {
@@ -46,7 +67,7 @@ export const markdownlintSentencesPerLine = {
 				continue;
 			}
 
-			visitLine(line, i + 1, onError);
+			visitLine(line, i + 1, onError, additionalAbbreviations);
 		}
 	},
 	names: ["markdownlint-sentences-per-line"],

--- a/packages/sentences-per-line/README.md
+++ b/packages/sentences-per-line/README.md
@@ -32,3 +32,10 @@ getIndexBeforeSecondSentence("The only sentence.");
 // 15
 getIndexBeforeSecondSentence("First sentence. Second sentence.");
 ```
+
+It optionally takes in an array of additional words to treat as abbreviations instead of sentence endings.
+
+```ts
+// undefined
+getIndexBeforeSecondSentence("Bonjour Mme. Dupont.", ["Mme."]);
+```

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
@@ -78,4 +78,18 @@ Abc. Def.
 
 		expect(actual).toBe(expected);
 	});
+
+	test("returns an index when given a French abbreviation that is not ignored", () => {
+		const actual = getIndexBeforeSecondSentence("Bonjour Mme. Dupont.");
+
+		expect(actual).toBe(12);
+	});
+
+	test("returns undefined when given a French abbreviation in customIgnoredWords", () => {
+		const actual = getIndexBeforeSecondSentence("Bonjour Mme. Dupont.", [
+			"Mme.",
+		]);
+
+		expect(actual).toBe(undefined);
+	});
 });

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
@@ -4,7 +4,10 @@ import { doesEndWithIgnoredWord } from "./doesEndWithIgnoredWord.ts";
  * @returns The first index after the period, question mark, or exclamation mark of the line's first sentence,
  * if a second sentence follows it.
  */
-export function getIndexBeforeSecondSentence(line: string) {
+export function getIndexBeforeSecondSentence(
+	line: string,
+	customIgnoredWords: string[] = [],
+) {
 	let i: number | undefined = 0;
 
 	// Ignore headings
@@ -27,7 +30,7 @@ export function getIndexBeforeSecondSentence(line: string) {
 			(line[i] === "." || line[i] === "!" || line[i] === "?") &&
 			line[i + 1] === " " &&
 			isCapitalizedAlphabetCharacter(line[i + 2]) &&
-			!doesEndWithIgnoredWord(line.substring(0, i + 1))
+			!doesEndWithIgnoredWord(line.substring(0, i + 1), customIgnoredWords)
 		) {
 			return i + 1;
 		}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #27
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes the list of ignored abbreviations configurable in every plugin, so docs in other languages can add their own (e.g. French `Mme.`).

| Package                                | Option                                     | Configured in                          |
| :------------------------------------- | :----------------------------------------- | :------------------------------------- |
| `eslint-plugin-sentences-per-line`     | `additionalAbbreviations`                  | The `one` rule's options object        |
| `markdownlint-sentences-per-line`      | `additional_abbreviations`                 | The rule's markdownlint config object  |
| `prettier-plugin-sentences-per-line`   | `sentencesPerLineAdditionalAbbreviations`  | Prettier config (already on `main`)    |

### `sentences-per-line`

`getIndexBeforeSecondSentence` now takes an optional second `customIgnoredWords` parameter that it forwards to `doesEndWithIgnoredWord`, which already supported extra words but had no caller path from this function.

### `eslint-plugin-sentences-per-line`

The `one` rule had `schema: []`, so it now has a real options object with `additionalProperties: false`, typed through the `MarkdownRuleDefinition` options generic (no casts):

```js
export default [
	{
		rules: {
			"sentences-per-line/one": ["error", { additionalAbbreviations: ["Mme."] }],
		},
	},
];
```

### `markdownlint-sentences-per-line`

The rule reads an `additional_abbreviations` array of strings out of its own markdownlint config (`params.config`), matching the `snake_case` keys markdownlint's built-in rules use (`line_length`, `code_blocks`, `ignore_words`).

```json
{
	"markdownlint-sentences-per-line": {
		"additional_abbreviations": ["Mme."]
	}
}
```

### `prettier-plugin-sentences-per-line`

Previously done by #815.

💖

🤖 Generated with [Claude Code](https://claude.com/claude-code)
