### PR TITLE
fix: remove the space between sentences when fixing

### DIFF
--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
@@ -1,5 +1,27 @@
+import markdown from "@eslint/markdown";
+import { Linter } from "eslint";
+import { describe, expect, it } from "vitest";
+
 import { one } from "./one.ts";
 import { ruleTester } from "./ruleTester.ts";
+
+function fixRepeatedly(code: string) {
+	return new Linter().verifyAndFix(
+		code,
+		[
+			{
+				files: ["**/*.md"],
+				language: "markdown/commonmark",
+				plugins: {
+					markdown,
+					"sentences-per-line": { rules: { one } },
+				},
+				rules: { "sentences-per-line/one": "error" },
+			},
+		],
+		"file.md",
+	).output;
+}
 
 ruleTester.run("one", one, {
 	invalid: [
@@ -14,7 +36,7 @@ ruleTester.run("one", one, {
 					messageId: "multiple",
 				},
 			],
-			output: "Abc. \nDef.",
+			output: "Abc.\nDef.",
 		},
 		{
 			code: `
@@ -38,7 +60,7 @@ Abc. Def.
 Abc. Def.
 \`\`\`
 
-Abc. 
+Abc.
 Def.
 `,
 		},
@@ -53,7 +75,7 @@ Def.
 					messageId: "multiple",
 				},
 			],
-			output: "Hello! \nWorld.",
+			output: "Hello!\nWorld.",
 		},
 		{
 			code: "Hello? World.",
@@ -66,7 +88,7 @@ Def.
 					messageId: "multiple",
 				},
 			],
-			output: "Hello? \nWorld.",
+			output: "Hello?\nWorld.",
 		},
 		{
 			code: "Really?! Wow.",
@@ -79,7 +101,7 @@ Def.
 					messageId: "multiple",
 				},
 			],
-			output: "Really?! \nWow.",
+			output: "Really?!\nWow.",
 		},
 		{
 			code: "Hello! World! Again.",
@@ -92,7 +114,7 @@ Def.
 					messageId: "multiple",
 				},
 			],
-			output: "Hello! \nWorld! Again.",
+			output: "Hello!\nWorld! Again.",
 		},
 		{
 			code: "1. Hello! World.",
@@ -105,7 +127,20 @@ Def.
 					messageId: "multiple",
 				},
 			],
-			output: "1. Hello! \nWorld.",
+			output: "1. Hello!\nWorld.",
+		},
+		{
+			code: "&amp; Abc. Def.",
+			errors: [
+				{
+					column: 11,
+					endColumn: 12,
+					endLine: 1,
+					line: 1,
+					messageId: "multiple",
+				},
+			],
+			output: "&amp; Abc.\nDef.",
 		},
 	],
 	valid: [
@@ -137,4 +172,18 @@ Def.
 		"Hello!",
 		"Hello?",
 	],
+});
+
+describe("one", () => {
+	it("splits every sentence onto its own line when fixing repeatedly", () => {
+		const actual = fixRepeatedly("Foo. Bar. Baz. Foo2. Bar2.\n");
+
+		expect(actual).toBe("Foo.\nBar.\nBaz.\nFoo2.\nBar2.\n");
+	});
+
+	it("splits every sentence onto its own line when the source already has a line ending in a space", () => {
+		const actual = fixRepeatedly("Foo. \nBar. Baz. Foo2. Bar2.\n");
+
+		expect(actual).toBe("Foo. \nBar.\nBaz.\nFoo2.\nBar2.\n");
+	});
 });

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
@@ -6,19 +6,24 @@ import { getIndexBeforeSecondSentence } from "sentences-per-line";
 export const one: MarkdownRuleDefinition = {
 	create(context) {
 		function checkTextNode(node: Text) {
-			const index = getIndexBeforeSecondSentence(node.value);
+			// Text node values can differ in length from their source text, such as
+			// with escapes and entities, so indices are computed from the source to
+			// keep them aligned with the offsets used to report and fix.
+			const index = getIndexBeforeSecondSentence(
+				context.sourceCode.getText(node),
+			);
 			if (!index) {
 				return;
 			}
 
 			/* eslint-disable @typescript-eslint/no-non-null-assertion */
 			const start = node.position!.start;
-			const insertion = start.offset! + index + 1;
+			const spaceStart = start.offset! + index;
 			/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
 			context.report({
 				fix(fixer) {
-					return fixer.insertTextAfterRange([insertion, insertion], "\n");
+					return fixer.replaceTextRange([spaceStart, spaceStart + 1], "\n");
 				},
 				loc: {
 					end: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #825
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The ESLint fixer inserted `\n` after the space between sentences, leaving a trailing space. Markdown text nodes drop that trailing space, so `node.value` drifted one character out of sync with `node.position` on each subsequent fix pass, producing the mangling in #825.

- The fixer now replaces the space with the newline instead of inserting after it.
- Sentence boundaries are found in `context.sourceCode.getText(node)` rather than `node.value`, so already-drifted documents can't be corrupted either.
- Report locations come from `sourceCode.getLocFromIndex`, fixing the line/column for text nodes that span multiple source lines.

The markdownlint and Prettier packages already delete the space and aren't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
