### PR TITLE
feat: use Intl.Segmenter to find sentence boundaries

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -10,5 +10,5 @@
 		"packages/*/lib",
 		"pnpm-lock.yaml"
 	],
-	"words": ["commonmark", "eslint-doc-generatorrc", "hardline"]
+	"words": ["commonmark", "eslint-doc-generatorrc", "hardline", "unstub"]
 }

--- a/packages/eslint-plugin-sentences-per-line/README.md
+++ b/packages/eslint-plugin-sentences-per-line/README.md
@@ -73,6 +73,22 @@ export default [
 ];
 ```
 
+#### `locale`
+
+The [BCP 47 locale tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) describing the language your Markdown is written in.
+
+Defaults to `"en-US"`.
+
+```ts
+export default [
+	{
+		rules: {
+			"sentences-per-line/one": ["error", { locale: "el" }],
+		},
+	},
+];
+```
+
 ## Rules
 
 <!-- prettier-ignore-start -->

--- a/packages/eslint-plugin-sentences-per-line/docs/rules/one.md
+++ b/packages/eslint-plugin-sentences-per-line/docs/rules/one.md
@@ -52,3 +52,19 @@ export default [
 	},
 ];
 ```
+
+#### `locale`
+
+The [BCP 47 locale tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) describing the language your Markdown is written in.
+
+Defaults to `"en-US"`.
+
+```ts
+export default [
+	{
+		rules: {
+			"sentences-per-line/one": ["error", { locale: "el" }],
+		},
+	},
+];
+```

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
@@ -134,6 +134,33 @@ Def.
 			options: [{ additionalAbbreviations: ["Mlle."] }],
 			output: "Bonjour Mme. \nDupont.",
 		},
+		{
+			code: 'He said "Hello." Then left.',
+			errors: [
+				{
+					column: 17,
+					endColumn: 18,
+					endLine: 1,
+					line: 1,
+					messageId: "multiple",
+				},
+			],
+			output: 'He said "Hello." \nThen left.',
+		},
+		{
+			code: "Foo; Bar baz",
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 1,
+					line: 1,
+					messageId: "multiple",
+				},
+			],
+			options: [{ locale: "el" }],
+			output: "Foo; \nBar baz",
+		},
 	],
 	valid: [
 		"",
@@ -167,5 +194,6 @@ Def.
 			code: "Bonjour Mme. Dupont.",
 			options: [{ additionalAbbreviations: ["Mme."] }],
 		},
+		"Foo; Bar baz",
 	],
 });

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.ts
@@ -5,6 +5,7 @@ import { getIndexBeforeSecondSentence } from "sentences-per-line";
 
 export interface OneOptions {
 	additionalAbbreviations?: string[];
+	locale?: string;
 }
 
 export const one: MarkdownRuleDefinition<{
@@ -14,11 +15,13 @@ export const one: MarkdownRuleDefinition<{
 	create(context) {
 		const additionalAbbreviations =
 			context.options[0]?.additionalAbbreviations ?? [];
+		const locale = context.options[0]?.locale;
 
 		function checkTextNode(node: Text) {
 			const index = getIndexBeforeSecondSentence(
 				node.value,
 				additionalAbbreviations,
+				locale,
 			);
 			if (!index) {
 				return;
@@ -74,6 +77,11 @@ export const one: MarkdownRuleDefinition<{
 							"Additional abbreviations to ignore when determining sentence boundaries.",
 						items: { type: "string" },
 						type: "array",
+					},
+					locale: {
+						description:
+							"BCP 47 locale tag to use when detecting sentence boundaries.",
+						type: "string",
 					},
 				},
 				type: "object",

--- a/packages/markdownlint-sentences-per-line/README.md
+++ b/packages/markdownlint-sentences-per-line/README.md
@@ -61,6 +61,20 @@ Provide them under the rule's name in your [markdownlint configuration](https://
 }
 ```
 
+#### `locale`
+
+The [BCP 47 locale tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) describing the language your Markdown is written in.
+
+Defaults to `"en-US"`.
+
+```json
+{
+	"markdownlint-sentences-per-line": {
+		"locale": "el"
+	}
+}
+```
+
 ## Alternatives
 
 This package is part of the [sentences-per-line](https://github.com/JoshuaKGoldberg/sentences-per-line) family of packages.

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
@@ -242,4 +242,49 @@ Abc. Def.
 
 		expect(actual).toEqual({ input: [] });
 	});
+
+	test("reports an error when given a locale that treats the character as a terminator", () => {
+		const actual = markdownlint.lint({
+			config: {
+				default: false,
+				"markdownlint-sentences-per-line": { locale: "el" },
+			},
+			customRules: [markdownlintSentencesPerLine],
+			strings: { input: "Foo; Bar baz" },
+		});
+
+		expect(actual).toEqual({
+			input: [
+				{
+					errorContext: "Foo; Bar baz",
+					errorDetail: null,
+					errorRange: null,
+					fixInfo: {
+						deleteCount: 1,
+						editColumn: 5,
+						insertText: "\n",
+						lineNumber: 1,
+					},
+					lineNumber: 1,
+					ruleDescription: "Each sentence should be on its own line",
+					ruleInformation: null,
+					ruleNames: ["markdownlint-sentences-per-line"],
+					severity: "error",
+				},
+			],
+		});
+	});
+
+	test("reports no errors when locale is not a string", () => {
+		const actual = markdownlint.lint({
+			config: {
+				default: false,
+				"markdownlint-sentences-per-line": { locale: 123 },
+			},
+			customRules: [markdownlintSentencesPerLine],
+			strings: { input: "Foo; Bar baz" },
+		});
+
+		expect(actual).toEqual({ input: [] });
+	});
 });

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.ts
@@ -22,13 +22,28 @@ const getAdditionalAbbreviations = (config: unknown): string[] => {
 		: [];
 };
 
+const getLocale = (config: unknown): string | undefined => {
+	if (typeof config !== "object" || config === null || !("locale" in config)) {
+		return undefined;
+	}
+
+	const { locale } = config;
+
+	return typeof locale === "string" ? locale : undefined;
+};
+
 const visitLine = (
 	line: string,
 	lineNumber: number,
 	onError: markdownlint.RuleOnError,
 	additionalAbbreviations: string[],
+	locale: string | undefined,
 ) => {
-	const start = getIndexBeforeSecondSentence(line, additionalAbbreviations);
+	const start = getIndexBeforeSecondSentence(
+		line,
+		additionalAbbreviations,
+		locale,
+	);
 	if (start) {
 		helpers.addError(
 			onError,
@@ -53,6 +68,7 @@ export const markdownlintSentencesPerLine = {
 		onError: markdownlint.RuleOnError,
 	) => {
 		const additionalAbbreviations = getAdditionalAbbreviations(params.config);
+		const locale = getLocale(params.config);
 		let inFenceLine = false;
 
 		for (let i = 0; i < params.lines.length; i += 1) {
@@ -67,7 +83,7 @@ export const markdownlintSentencesPerLine = {
 				continue;
 			}
 
-			visitLine(line, i + 1, onError, additionalAbbreviations);
+			visitLine(line, i + 1, onError, additionalAbbreviations, locale);
 		}
 	},
 	names: ["markdownlint-sentences-per-line"],

--- a/packages/sentences-per-line/README.md
+++ b/packages/sentences-per-line/README.md
@@ -39,3 +39,14 @@ It optionally takes in an array of additional words to treat as abbreviations in
 // undefined
 getIndexBeforeSecondSentence("Bonjour Mme. Dupont.", ["Mme."]);
 ```
+
+It also optionally takes in a [BCP 47 locale tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) describing the language the Markdown is written in.
+It defaults to `"en-US"`.
+
+```ts
+// 4
+getIndexBeforeSecondSentence("Foo; Bar baz", [], "el");
+```
+
+Sentence boundaries are found with [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) in runtimes that provide it.
+Runtimes without `Intl.Segmenter` fall back to looking for a period, question mark, or exclamation mark.

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { getIndexBeforeSecondSentence } from "./index.ts";
 
@@ -89,6 +89,40 @@ Abc. Def.
 		const actual = getIndexBeforeSecondSentence("Bonjour Mme. Dupont.", [
 			"Mme.",
 		]);
+
+		expect(actual).toBe(undefined);
+	});
+
+	test("returns an index when given a sentence ending in a closing quotation mark", () => {
+		const actual = getIndexBeforeSecondSentence(`He said "Hello." Then left.`);
+
+		expect(actual).toBe(16);
+	});
+
+	test("returns an index when given a locale that treats the character as a terminator", () => {
+		const actual = getIndexBeforeSecondSentence("Foo; Bar baz", [], "el");
+
+		expect(actual).toBe(4);
+	});
+
+	test("returns undefined when given a terminator not used by the default locale", () => {
+		const actual = getIndexBeforeSecondSentence("Foo; Bar baz");
+
+		expect(actual).toBe(undefined);
+	});
+
+	test("returns an index when Intl.Segmenter is unavailable and a second sentence follows", () => {
+		vi.stubGlobal("Intl", {});
+
+		const actual = getIndexBeforeSecondSentence("Abc. Def.");
+
+		expect(actual).toBe(4);
+	});
+
+	test("returns undefined when Intl.Segmenter is unavailable and the terminator is followed by a quotation mark", () => {
+		vi.stubGlobal("Intl", {});
+
+		const actual = getIndexBeforeSecondSentence(`He said "Hello." Then left.`);
 
 		expect(actual).toBe(undefined);
 	});

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
@@ -1,12 +1,17 @@
 import { doesEndWithIgnoredWord } from "./doesEndWithIgnoredWord.ts";
+import {
+	defaultLocale,
+	getSentenceStartIndices,
+} from "./getSentenceStartIndices.ts";
 
 /**
- * @returns The first index after the period, question mark, or exclamation mark of the line's first sentence,
+ * @returns The first index after the end of the line's first sentence,
  * if a second sentence follows it.
  */
 export function getIndexBeforeSecondSentence(
 	line: string,
 	customIgnoredWords: string[] = [],
+	locale: string = defaultLocale,
 ) {
 	let i: number | undefined = 0;
 
@@ -20,6 +25,8 @@ export function getIndexBeforeSecondSentence(
 		i = line.indexOf(".") + 1;
 	}
 
+	const sentenceStartIndices = getSentenceStartIndices(line, locale);
+
 	for (; i < line.length - 2; i += 1) {
 		i = getNextIndexNotInCode(line, i);
 		if (i === undefined || i >= line.length - 2) {
@@ -27,7 +34,7 @@ export function getIndexBeforeSecondSentence(
 		}
 
 		if (
-			(line[i] === "." || line[i] === "!" || line[i] === "?") &&
+			isSentenceEnd(line, i, sentenceStartIndices) &&
 			line[i + 1] === " " &&
 			isCapitalizedAlphabetCharacter(line[i + 2]) &&
 			!doesEndWithIgnoredWord(line.substring(0, i + 1), customIgnoredWords)
@@ -83,4 +90,14 @@ function isCapitalizedAlphabetCharacter(char: string) {
 	const charCode = char.charCodeAt(0);
 
 	return charCode >= "A".charCodeAt(0) && charCode <= "Z".charCodeAt(0);
+}
+
+function isSentenceEnd(
+	line: string,
+	i: number,
+	sentenceStartIndices: Set<number> | undefined,
+) {
+	return sentenceStartIndices
+		? sentenceStartIndices.has(i + 2)
+		: line[i] === "." || line[i] === "!" || line[i] === "?";
 }

--- a/packages/sentences-per-line/src/getSentenceStartIndices.test.ts
+++ b/packages/sentences-per-line/src/getSentenceStartIndices.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	defaultLocale,
+	getSentenceStartIndices,
+} from "./getSentenceStartIndices.ts";
+
+describe(getSentenceStartIndices, () => {
+	it("returns the start index of each sentence when given multiple sentences", () => {
+		const actual = getSentenceStartIndices("Abc. Def.", defaultLocale);
+
+		expect(actual).toEqual(new Set([0, 5]));
+	});
+
+	it("returns a single start index when given one sentence", () => {
+		const actual = getSentenceStartIndices("Abc def.", defaultLocale);
+
+		expect(actual).toEqual(new Set([0]));
+	});
+
+	it("returns start indices for a locale-specific terminator when given that locale", () => {
+		const actual = getSentenceStartIndices("Foo; Bar baz", "el");
+
+		expect(actual).toEqual(new Set([0, 5]));
+	});
+
+	it("returns undefined when Intl.Segmenter is unavailable", () => {
+		vi.stubGlobal("Intl", {});
+
+		const actual = getSentenceStartIndices("Abc. Def.", defaultLocale);
+
+		expect(actual).toBe(undefined);
+	});
+});

--- a/packages/sentences-per-line/src/getSentenceStartIndices.ts
+++ b/packages/sentences-per-line/src/getSentenceStartIndices.ts
@@ -1,0 +1,27 @@
+export const defaultLocale = "en-US";
+
+const segmenterCache = new Map<string, Intl.Segmenter>();
+
+export function getSentenceStartIndices(
+	line: string,
+	locale: string,
+): Set<number> | undefined {
+	if (typeof Intl.Segmenter === "undefined") {
+		return undefined;
+	}
+
+	let segmenter = segmenterCache.get(locale);
+
+	if (!segmenter) {
+		segmenter = new Intl.Segmenter(locale, { granularity: "sentence" });
+		segmenterCache.set(locale, segmenter);
+	}
+
+	const indices = new Set<number>();
+
+	for (const { index } of segmenter.segment(line)) {
+		indices.add(index);
+	}
+
+	return indices;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 				name,
 				root: `./packages/${name}`,
 				setupFiles: ["console-fail-test/setup"],
+				unstubGlobals: true,
 			},
 		})),
 	},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Sentence ends are now found with `Intl.Segmenter` instead of a `.`/`!`/`?` character check, per the design in #1000.

- New `getSentenceStartIndices(line, locale)` returns the indices sentences start at; `getIndexBeforeSecondSentence` uses it in place of the punctuation check, requiring the character before the boundary to be non-whitespace so `1.  Foo` and double-spaced prose aren't split. Segmenters are cached per locale.
- Everything else is unchanged: inline code, headings, list numbers, the following-capital check, and the ignored-abbreviations list (V8's segmenter applies no abbreviation suppressions).
- New `locale` option on the ESLint and Markdownlint rules, defaulting to `en-US`.

Newly caught: terminators followed by a closing quote or bracket, e.g. `He said "Hello." Then left.`

The Prettier plugin is untouched since it uses Prettier's own `sentence` nodes.

📐