### PR TITLE
fix: don't split sentences inside Markdown table rows

### DIFF
--- a/packages/eslint-plugin-sentences-per-line/README.md
+++ b/packages/eslint-plugin-sentences-per-line/README.md
@@ -50,6 +50,8 @@ export default [
 ];
 ```
 
+Sentences within Markdown table rows are left alone, as splitting a row across lines would break the table.
+
 ### Options
 
 #### `additionalAbbreviations`

--- a/packages/eslint-plugin-sentences-per-line/docs/rules/one.md
+++ b/packages/eslint-plugin-sentences-per-line/docs/rules/one.md
@@ -30,6 +30,14 @@ First sentence.
 Second sentence
 ```
 
+Table rows are never split, as a line break inside one would break the table:
+
+```md
+| Column                          |
+| ------------------------------- |
+| First sentence. Second sentence |
+```
+
 ## Options
 
 ### `additionalAbbreviations`

--- a/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
+++ b/packages/eslint-plugin-sentences-per-line/src/rules/one.test.ts
@@ -134,6 +134,32 @@ Def.
 			options: [{ additionalAbbreviations: ["Mlle."] }],
 			output: "Bonjour Mme. \nDupont.",
 		},
+		{
+			code: `
+| A | B |
+| - | - |
+| Abc. Def. | Ghi. Jkl. |
+
+Abc. Def.
+`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 6,
+					line: 6,
+					messageId: "multiple",
+				},
+			],
+			output: `
+| A | B |
+| - | - |
+| Abc. Def. | Ghi. Jkl. |
+
+Abc. 
+Def.
+`,
+		},
 	],
 	valid: [
 		"",
@@ -163,6 +189,16 @@ Def.
 		"`Hello?` World.",
 		"Hello!",
 		"Hello?",
+		`
+| A | B |
+| - | - |
+| Abc. Def. | Ghi |
+`,
+		`
+| A | B |
+| - | - |
+| Abc. Def. | Ghi. Jkl. |
+`,
 		{
 			code: "Bonjour Mme. Dupont.",
 			options: [{ additionalAbbreviations: ["Mme."] }],

--- a/packages/markdownlint-sentences-per-line/README.md
+++ b/packages/markdownlint-sentences-per-line/README.md
@@ -41,6 +41,8 @@ Then provide it to [markdownlint-cli's `--rules`](https://github.com/igorshubovy
 markdownlint --rules markdownlint-sentences-per-line
 ```
 
+Sentences within Markdown table rows are left alone, as splitting a row across lines would break the table.
+
 ### Options
 
 #### `additional_abbreviations`

--- a/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
+++ b/packages/markdownlint-sentences-per-line/src/markdownlintSentencesPerLine.test.ts
@@ -119,6 +119,41 @@ Abc. Def.
 				lineNumber: 6,
 			},
 		],
+		[
+			`
+| A | B |
+| - | - |
+| Abc. Def. | Ghi |
+`,
+			undefined,
+		],
+		[
+			`
+| A | B |
+| - | - |
+| Abc. Def. | Ghi. Jkl. |
+`,
+			undefined,
+		],
+		[
+			`
+| A | B |
+| - | - |
+| Abc. Def. | Ghi. Jkl. |
+
+Abc. Def.
+`,
+			"Abc. Def.",
+			{
+				fixInfo: {
+					deleteCount: 1,
+					editColumn: 5,
+					insertText: "\n",
+					lineNumber: 6,
+				},
+				lineNumber: 6,
+			},
+		],
 	] as const)("%s", (input, errorContext, report?) => {
 		const actual = markdownlint.lint({
 			config: {

--- a/packages/prettier-plugin-sentences-per-line/README.md
+++ b/packages/prettier-plugin-sentences-per-line/README.md
@@ -38,6 +38,8 @@ Then add it to your [Prettier config's `plugins`](https://prettier.io/docs/plugi
 }
 ```
 
+Sentences within Markdown table rows are left alone, as splitting a row across lines would break the table.
+
 ### Options
 
 #### `sentencesPerLineAdditionalAbbreviations`

--- a/packages/prettier-plugin-sentences-per-line/src/index.test.ts
+++ b/packages/prettier-plugin-sentences-per-line/src/index.test.ts
@@ -67,6 +67,41 @@ describe("index", () => {
 				"> These values are the list of possible `process.platform`\n",
 			].join("\n"),
 		],
+
+		// https://github.com/JoshuaKGoldberg/sentences-per-line/issues/1135
+		[
+			["| A | B |", "| - | - |", "| Abc. Def. | Ghi |\n"].join("\n"),
+			[
+				"| A         | B   |",
+				"| --------- | --- |",
+				"| Abc. Def. | Ghi |\n",
+			].join("\n"),
+		],
+		[
+			["| A | B |", "| - | - |", "| Abc. Def. | Ghi. Jkl. |\n"].join("\n"),
+			[
+				"| A         | B         |",
+				"| --------- | --------- |",
+				"| Abc. Def. | Ghi. Jkl. |\n",
+			].join("\n"),
+		],
+		[
+			[
+				"| A | B |",
+				"| - | - |",
+				"| Abc. Def. | Ghi. Jkl. |",
+				"",
+				"Abc. Def.\n",
+			].join("\n"),
+			[
+				"| A         | B         |",
+				"| --------- | --------- |",
+				"| Abc. Def. | Ghi. Jkl. |",
+				"",
+				"Abc.",
+				"Def.\n",
+			].join("\n"),
+		],
 	])("%j", async (input, expected = input) => {
 		const actual = await format(input, { filepath: "test.md" });
 		expect(actual).toBe(expected);

--- a/packages/prettier-plugin-sentences-per-line/src/modifications/modifyNodeIfMultipleSentencesInLine.ts
+++ b/packages/prettier-plugin-sentences-per-line/src/modifications/modifyNodeIfMultipleSentencesInLine.ts
@@ -64,6 +64,11 @@ function walk(
 	node: Root | RootContent | SentenceNodeChild,
 	{ customAbbreviations }: Required<ModifyNodeOptions>,
 ) {
+	// Table cells must stay on their row's line, so they can't take a break
+	if (node.type === "table") {
+		return;
+	}
+
 	if ("children" in node && Array.isArray(node.children)) {
 		for (const child of node.children) {
 			if (child.type === "sentence") {

--- a/packages/sentences-per-line/README.md
+++ b/packages/sentences-per-line/README.md
@@ -33,6 +33,13 @@ getIndexBeforeSecondSentence("The only sentence.");
 getIndexBeforeSecondSentence("First sentence. Second sentence.");
 ```
 
+Lines that can't contain a line break, such as headings and table rows, are never reported.
+
+```ts
+// undefined
+getIndexBeforeSecondSentence("| First sentence. Second sentence. | Third |");
+```
+
 It optionally takes in an array of additional words to treat as abbreviations instead of sentence endings.
 
 ```ts

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.test.ts
@@ -73,6 +73,9 @@ Abc. Def.
 		["1. First sentence. Second one.", 18],
 		["``abc", undefined],
 		["Hello world! Another sentence!", 12],
+		["| Abc. Def. | Ghi |", undefined],
+		["| Abc. Def. | Ghi. Jkl. |", undefined],
+		["  | Abc. Def. | Ghi |", undefined],
 	] as const)("%s", (input, expected) => {
 		const actual = getIndexBeforeSecondSentence(input);
 

--- a/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
+++ b/packages/sentences-per-line/src/getIndexBeforeSecondSentence.ts
@@ -15,6 +15,11 @@ export function getIndexBeforeSecondSentence(
 		return undefined;
 	}
 
+	// Ignore table rows, as a line break inside one would split the table apart
+	if (/^\s*\|/.test(line)) {
+		return undefined;
+	}
+
 	// Skip any starting list number, e.g. "1. " or " 1. "
 	if (/^\s*\d+\./.test(line)) {
 		i = line.indexOf(".") + 1;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1135
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/sentences-per-line/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/sentences-per-line/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

A Markdown table row has to live on one line, so inserting a sentence break inside a cell breaks the table.

- `sentences-per-line` now bails on lines starting with `|` (including inside block quotes, `> |`), alongside the existing heading check. This covers the markdownlint and ESLint (`markdown/commonmark`) consumers.
- `prettier-plugin-sentences-per-line` no longer walks into `table` nodes.

Out of scope: GFM tables without leading pipes, and `markdown/commonmark` paragraphs that start with prose before a table row.

📐